### PR TITLE
Going back, empty recent message and length limit  issues fixed

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -187,7 +187,7 @@ class _LoginPageState extends State<LoginPage> {
                                   fontWeight: FontWeight.bold),
                               recognizer: TapGestureRecognizer()
                                 ..onTap = () {
-                                  nextScreen(context, const RegisterPage());
+                                  nextScreenReplace(context, const RegisterPage());
                                 })
                         ]))
                   ],

--- a/lib/pages/register_page.dart
+++ b/lib/pages/register_page.dart
@@ -159,7 +159,7 @@ class _RegisterPageState extends State<RegisterPage> {
                           text:"Login Now",
                           style: const TextStyle(color: Color.fromARGB(255, 6, 68, 161),decoration: TextDecoration.underline,fontWeight:FontWeight.bold),
                           recognizer: TapGestureRecognizer()..onTap=(){
-                            nextScreen(context, const LoginPage());
+                            nextScreenReplace(context, const LoginPage());
                           }
                         )
                       ]

--- a/lib/widgets/group_title.dart
+++ b/lib/widgets/group_title.dart
@@ -87,7 +87,7 @@ String recentMessage = "";
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
           subtitle:
-          recentMessageSender == "" || recentMessage == ""
+          recentMessageSender == "" && recentMessage == ""
               ? const Text("No recent messages")
               :
            Text(

--- a/lib/widgets/group_title.dart
+++ b/lib/widgets/group_title.dart
@@ -41,7 +41,7 @@ String recentMessage = "";
   getRecentMessageAndSender() {
     DatabaseServices().getRecentMessage(widget.groupId).then((val) {
       setState(() {
-        recentMessage = val;
+        recentMessage = val.length>30? val.substring(0,30)+" .....":val;
       });
     });
     DatabaseServices().getRecentMessageSender(widget.groupId).then((val) {

--- a/lib/widgets/group_title.dart
+++ b/lib/widgets/group_title.dart
@@ -87,7 +87,7 @@ String recentMessage = "";
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
           subtitle:
-          recentMessageSender == "" && recentMessage == ""
+           recentMessage == ""
               ? const Text("No recent messages")
               :
            Text(


### PR DESCRIPTION
### **Bug description**

- users can able to go back from login page to register page and vice versa
- Possibility of showing empty recent message
- There is no limitation for displaying recent message

### **Solution description**

- Replace the nextScreen function with  nextScreenReplace in login and register page
- Replace the or operator ( || ) with and operator (&&) in [group_title](https://github.com/abhishakedahal/sambaad/blob/master/lib/widgets/group_title.dart)
- Set  length limit while fetching the recent message from database

### **Result after bug fixed**

- Users can't able to go back from login and register page unnecessarily
- There is no change of showing empty recent messages
- Only 30 characters of recent message will be shown in subtitle