### PR TITLE
adding focusedErrorBorder in login page

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -87,6 +87,11 @@ class _LoginPageState extends State<LoginPage> {
                                   width: 2, color: Color(0xFF3A98B9)),
                               borderRadius: BorderRadius.circular(50.0),
                             ),
+                            focusedErrorBorder: OutlineInputBorder(
+                              borderSide: BorderSide(
+                                  width: 2, color: Color(0xFF3A98B9)),
+                              borderRadius: BorderRadius.circular(50.0),
+                            ),
                             labelText: "Email",
                             prefixIcon: Icon(
                               Icons.email,
@@ -125,6 +130,11 @@ class _LoginPageState extends State<LoginPage> {
                               borderRadius: BorderRadius.circular(50.0),
                             ),
                             errorBorder: OutlineInputBorder(
+                              borderSide: BorderSide(
+                                  width: 2, color: Color(0xFF3A98B9)),
+                              borderRadius: BorderRadius.circular(50.0),
+                            ),
+                            focusedErrorBorder: OutlineInputBorder(
                               borderSide: BorderSide(
                                   width: 2, color: Color(0xFF3A98B9)),
                               borderRadius: BorderRadius.circular(50.0),


### PR DESCRIPTION

### **About this issue:**

- If you try to write something in the input field after an error occurs, the borders may become invisible except for the bottom border. 

### **Solution**

- Add focusedErrorBorder in textFormField